### PR TITLE
Show the viewer by default

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,10 +1,6 @@
 'use strict';
 
 var router = require('express').Router();
-var auth = require('../middleware/auth');
-var renderAdminPage = require('../renderAdminPage');
-
-router.route('/').all(auth);
 
 // GET home page
 router.get('/', function(req, res, next) {

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -7,7 +7,13 @@ var renderAdminPage = require('../renderAdminPage');
 router.route('/').all(auth);
 
 // GET home page
-router.get('/', renderAdminPage);
+router.get('/', function(req, res, next) {
+	res.render('viewer', {
+		app: 'viewer',
+		hostname: req.headers.host,
+		title: req.query.title
+	});
+});
 
 // Vanity redirect for screen filtering
 router.get('/:id(\\d{3,5})', function(req, res) {


### PR DESCRIPTION
Set the response to '/' to be the viewer rather than the admin page.

The admin page like usual can be got to by going to '/admin'.

Fixes #12 
