### PR TITLE
Use the original url when authenticating

### DIFF
--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -7,6 +7,15 @@ module.exports = function(req, res, next) {
 	} else if (req.query.redirect === 'true') {
 		next();
 	} else {
-		authS3O(req, res, next);
+
+		// since it maybe used in a middleware restore original url to the request object.
+		const oldUrl = req.url;
+		req.url = req.originalUrl;
+		authS3O(req, res, function () {
+
+			// restore the old url for routing purposes
+			req.url = oldUrl;
+			next();
+		});
 	}
 };


### PR DESCRIPTION
Fixes an issue where we were the url was the relative url of the middleware rather than the original url of the request.
