### PR TITLE
Add sandboxing attributes to the iframe to prevent top level navigation

### DIFF
--- a/views/viewer.handlebars
+++ b/views/viewer.handlebars
@@ -15,7 +15,7 @@
 		<span class="url">{{hostname}}/<span class='screen-id'></span>
 	</div>
 
-	<iframe frameBorder="0" seamless class='full panel panel-active'></iframe>
+	<iframe frameBorder="0" sandbox="allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts" seamless class='full panel panel-active'></iframe>
 
 	<!-- <webview src="http://bbc.co.uk/news" class="full panel panel-active"></webview> -->
 


### PR DESCRIPTION
I added the sandboxing params you suggested and tested it on http://video.ft.com it works well. :+1: 

Fixes #3 
