### PR TITLE
Express ftwebservice

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "body-parser": "~1.12.0",
     "bower": "1.4.1",
+    "chai": "^3.4.1",
     "cheerio": "^0.19.0",
     "cookie": "^0.2.0",
     "cookie-parser": "~1.3.4",
@@ -24,6 +25,8 @@
     "is-url-superb": "^2.0.0",
     "lodash": "^3.10.1",
     "lru-cache": "^2.6.5",
+    "mocha": "^2.3.3",
+    "mockery": "^1.4.0",
     "moment": "^2.10.6",
     "morgan": "~1.5.1",
     "node-fetch": "^1.3.2",
@@ -34,16 +37,12 @@
     "serve-favicon": "~2.2.0",
     "showdown": "^1.2.2",
     "simplewebrtc": "^1.19.1",
+    "sinon": "^1.17.2",
     "socket.io": "^1.3.7",
-    "socket.io-client": "^1.3.7",
-    "mocha": "^2.3.3",
-    "chai": "^3.4.1",
-    "mockery": "^1.4.0",
-    "sinon": "^1.17.2"
+    "socket.io-client": "^1.3.7"
   },
   "engines": {
     "node": "4.2.2"
   },
-  "devDependencies": {
-  }
+  "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "debug": "~2.1.1",
     "dotenv": "^1.2.0",
     "express": "~4.12.2",
+    "express-ftwebservice": "^2.0.2",
     "express-handlebars": "^2.0.1",
     "gulp": "latest",
     "htmlparser": "^1.7.7",
@@ -34,15 +35,15 @@
     "showdown": "^1.2.2",
     "simplewebrtc": "^1.19.1",
     "socket.io": "^1.3.7",
-    "socket.io-client": "^1.3.7"
+    "socket.io-client": "^1.3.7",
+    "mocha": "^2.3.3",
+    "chai": "^3.4.1",
+    "mockery": "^1.4.0",
+    "sinon": "^1.17.2"
   },
   "engines": {
     "node": "4.2.2"
   },
   "devDependencies": {
-    "chai": "^3.4.1",
-    "mocha": "^2.3.3",
-    "mockery": "^1.4.0",
-    "sinon": "^1.17.2"
   }
 }

--- a/runbook.json
+++ b/runbook.json
@@ -1,0 +1,14 @@
+{
+	"schemaVersion": 1,
+	"name": "Screens",
+	"purpose": "Digital signage solution for displaying webpages and controling them from a central server.",
+	"audience": "public",
+	"serviceTier": "bronze",
+	"dateCreated": "2015-11-02",
+	"contacts": [
+		{ "name":"FT Labs team", "email":"ftlabs@ft.com", "rel":"owner", "domain":"All support enquiries" }
+	],
+	"links": [
+		{ "url":"https://github.com/ftlabs/screens", "category":"repo" }
+	]
+}

--- a/server/app.js
+++ b/server/app.js
@@ -13,7 +13,7 @@ const debug = require('debug')('screens:app');
 const cookie = require('cookie');
 const pages = require('./pages');
 const screens = require('./screens');
-const ftwebservice = require('ftwebservice');
+const ftwebservice = require('express-ftwebservice');
 
 const app = express();
 
@@ -47,7 +47,7 @@ app.use('/bower_components', express.static(path.join(__dirname, '../bower_compo
 
 // /__gtg, /__health, and /__about.
 ftwebservice(app, {
-	manifestPath: require('../package.json'),
+	manifestPath: path.join(__dirname, '../package.json'),
 	about: require('../runbook.json'),
 	healthCheck: require('../tests/healthcheck'),
 

--- a/server/app.js
+++ b/server/app.js
@@ -1,4 +1,6 @@
 /* global __dirname */
+'use strict';
+
 const express = require('express');
 const path = require('path');
 const favicon = require('serve-favicon');
@@ -11,6 +13,7 @@ const debug = require('debug')('screens:app');
 const cookie = require('cookie');
 const pages = require('./pages');
 const screens = require('./screens');
+const ftwebservice = require('ftwebservice');
 
 const app = express();
 
@@ -37,15 +40,25 @@ app.hbs = hbs;
 // Write HTTP request log using Morgan
 app.use(morganLogger('dev'));
 
-// Parse requests for body content and cookies
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: false }));
-app.use(cookieParser());
-
 // Serve static files
 app.use(favicon(path.join(__dirname, '../public/favicon.ico')));
 app.use(express.static(path.join(__dirname, '../public')));
 app.use('/bower_components', express.static(path.join(__dirname, '../bower_components')));
+
+// /__gtg, /__health, and /__about.
+ftwebservice(app, {
+	manifestPath: require('../package.json'),
+	about: require('../runbook.json'),
+	healthCheck: require('../tests/healthcheck'),
+
+	// TODO AE07122015: Once logging is merged check that the database can be connected to
+	goodToGoTest: () => Promise.resolve(true)
+});
+
+// Parse requests for body content and cookies
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: false }));
+app.use(cookieParser());
 
 // Serve routes
 app.use('/', require('./routes/index'));

--- a/tests/healthcheck.js
+++ b/tests/healthcheck.js
@@ -1,0 +1,47 @@
+'use strict';
+
+// TODO AE07122015: Once further tests are written encorporate them into the healthcheck
+
+const path = require('path');
+const Mocha = require('mocha');
+
+const mocha = new Mocha();
+mocha.addFile(path.join(__dirname, 'test.js'));
+
+// Return a promise that resolves to a set of healthchecks
+module.exports = function() {
+
+	// You might have several async checks that you need to perform or
+	// collect the results from, this is a really simplistic example
+	return new Promise(function(resolve) {
+		mocha.run(function (failures) {
+			if (failures === 0) {
+				resolve([
+					{
+						name: 'URL Transform Tests Passing',
+						ok: true,
+						severity: 2,
+						businessImpact: 'TODO',
+						technicalSummary: 'TODO',
+						panicGuide: 'TODO',
+						checkOutput: 'TODO',
+						lastUpdated: new Date().toISOString()
+					}
+				]);
+			} else {
+				resolve([
+					{
+						name: 'Failing to convert URLs',
+						ok: false,
+						severity: 2,
+						businessImpact: 'TODO',
+						technicalSummary: 'TODO',
+						panicGuide: 'TODO',
+						checkOutput: 'TODO',
+						lastUpdated: new Date().toISOString()
+					}
+				]);
+			}
+		});
+	});
+};


### PR DESCRIPTION
Fixes #17 

This adds the express ftwebservice to create the __about, __health and __gtg pages. 

The healthcheck has been hooked into the mocha tests. 
good to go should be hooked into the redis status once the logging pr is merged.
