### PR TITLE
id used before declared

### DIFF
--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -137,9 +137,9 @@ router.post('/clear', function(req, res) {
 
 router.post('/rename', function(req, res, next) {
 	const name = req.body.name;
+	const id = getScreenIDsForRequest(req);
 	const screen = screens.get(id)[0];
 	const oldName = screen ? screen.name : 'No screen present';
-	const id = getScreenIDsForRequest(req);
 	debug(req.cookies.s3o_username + ' renamed screen ' + id[0] + ' to ' + name);
 	log.logApi({
 		eventType: log.eventTypes.screenRenamed.id,


### PR DESCRIPTION
Renaming screens doesn't persist as the endpoint throws an error because we try to use the screen id to save the name before we've retrieved the id.
