### PR TITLE
Add docker workflow capabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM jakechampion/heroku-nodejs
+RUN npm i -g bower
+RUN bower install --allow-root 
+RUN gulp build

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node ./bin/www

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 If you don't have a Docker machine set-up:
 - Create a virtual machine (named default) -- `docker-machine create --driver virtualbox default` (change the driver value if using vmware)
 If/Once you have a Docker machine set-up:
-- Check that your machine is running -- `docker-machine ls`
+- Check that your machine is running -- `docker-machine ls` -- _It is active if it has a `*` in the `ACTIVE` column_
 - If machine is not running, boot it up -- `docker-machine start default`
 - Add environment variables to your computer in order to let Docker communicate with the virtual machine -- `eval "$(docker-machine env default)"` -- It is recommended to add this to your `bash_profile` or similar.
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@
 - Open the application in your browser of choice -- `open "http://$(docker-machine ip default):8080"`
 
 ##### [Creating a virtual machine for Docker](#creating-a-virtual-machine-for-docker)
- [VirtualBox](https://www.virtualbox.org/wiki/Downloads) or [VMWare](http://www.vmware.com/uk/).
 
+- Download and install [VirtualBox](https://www.virtualbox.org/wiki/Downloads) if you don't already have it installed.
 - Check if you already have a Docker machine set-up -- `docker-machine ls`
 If you don't have a Docker machine set-up:
 - Create a virtual machine (named default) -- `docker-machine create --driver virtualbox default` (change the driver value if using vmware)

--- a/README.md
+++ b/README.md
@@ -31,3 +31,11 @@ We can deploy either by using Heroku's Docker plugin or by the Git plugin.
 
 - Deploy a new release using Heroku's Docker plugin -- `heroku docker:release --app {APP_NAME}`
 - Deploy using Heroku's Git plugin -- `git push {HEROKU_GIT_REMOTE_NAME} master`
+
+These are not equivalent deployment processes:
+
+The Docker plugin will build a docker image, mount the container, tarball the app directory and send that to Heroku's releases API. 
+
+The Git plugin will push a branch to Heroku's Git repository, which will then be built using Heroku's buildpack, on installation of the application it will run `bower install && gulp build` as that is defined in the "post-install" script in the `package.json` file.
+
+By using the Docker plugin approach, we would be able to remove the development tools from being deployed to Heroku alongside the appliaction.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - Change in repository directory -- `cd screens`
 - If running OS X or Windows, [follow these steps for creating a virtual machine for Docker](#creating-a-virtual-machine-for-docker) -- This is a section in this file.
 - Build a Docker image -- `docker build .`
-- Spin up the web process in a container -- `docker-compose up web` -- `web` is defined in `docker-compose.yml`
+- Spin up the web process in a container -- `docker-compose up`
 - Open the application in your browser of choice -- `open "http://$(docker-machine ip default):8080"`
 
 ##### [Creating a virtual machine for Docker](#creating-a-virtual-machine-for-docker)

--- a/README.md
+++ b/README.md
@@ -7,13 +7,12 @@
 - [Heroku Toolbelt](https://toolbelt.heroku.com/)
 - Heroku Docker plugin -- `heroku plugins:install heroku-docker`
 
-If running OS X or Windows, [follow these steps for creating a virtual machine for Docker](#creating-a-virtual-machine-for-docker) -- This is a section in this readme file.
-
 #### Setting up development environment
 - Clone the repository -- `git clone git@github.com:ftlabs/screens.git`
 - Change in repository directory -- `cd screens`
+- If running OS X or Windows, [follow these steps for creating a virtual machine for Docker](#creating-a-virtual-machine-for-docker) -- This is a section in this file.
 - Build a Docker image -- `docker build .`
-- Spin up the web process in a container -- `docker-compose up web`
+- Spin up the web process in a container -- `docker-compose up web` -- `web` is defined in `docker-compose.yml`
 - Open the application in your browser of choice -- `open "http://$(docker-machine ip default):8080"`
 
 ##### [Creating a virtual machine for Docker](#creating-a-virtual-machine-for-docker)
@@ -21,11 +20,11 @@ If running OS X or Windows, [follow these steps for creating a virtual machine f
 
 - Check if you already have a Docker machine set-up -- `docker-machine ls`
 If you don't have a Docker machine set-up:
-- Create a virtual machine -- `docker-machine create --driver virtualbox default` (change the driver value if using vmware)
+- Create a virtual machine (named default) -- `docker-machine create --driver virtualbox default` (change the driver value if using vmware)
 If/Once you have a Docker machine set-up:
 - Check that your machine is running -- `docker-machine ls`
 - If machine is not running, boot it up -- `docker-machine start default`
-- Add environment variables to your computer in order to let Docker communicate with the virtual machine -- `eval "$(docker-machine env default)"`
+- Add environment variables to your computer in order to let Docker communicate with the virtual machine -- `eval "$(docker-machine env default)"` -- It is recommended to add this to your `bash_profile` or similar.
 
 ### Deploying
 We can deploy either by using Heroku's Docker plugin or by the Git plugin.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+## Screens
+
+### Development
+
+#### Prerequisites
+- [Docker](https://www.docker.com/docker-toolbox)
+- [Heroku Toolbelt](https://toolbelt.heroku.com/)
+- Heroku Docker plugin -- `heroku plugins:install heroku-docker`
+
+If running OS X or Windows, [follow these steps for creating a virtual machine for Docker](#creating-a-virtual-machine-for-docker) -- This is a section in this readme file.
+
+#### Setting up development environment
+- Clone the repository -- `git clone git@github.com:ftlabs/screens.git`
+- Change in repository directory -- `cd screens`
+- Build a Docker image -- `docker build .`
+- Spin up the web process in a container -- `docker-compose up web`
+- Open the application in your browser of choice -- `open "http://$(docker-machine ip default):8080"`
+
+##### [Creating a virtual machine for Docker](#creating-a-virtual-machine-for-docker)
+ [VirtualBox](https://www.virtualbox.org/wiki/Downloads) or [VMWare](http://www.vmware.com/uk/).
+
+- Check if you already have a Docker machine set-up -- `docker-machine ls`
+If you don't have a Docker machine set-up:
+- Create a virtual machine -- `docker-machine create --driver virtualbox default` (change the driver value if using vmware)
+If/Once you have a Docker machine set-up:
+- Check that your machine is running -- `docker-machine ls`
+- If machine is not running, boot it up -- `docker-machine start default`
+- Add environment variables to your computer in order to let Docker communicate with the virtual machine -- `eval "$(docker-machine env default)"`
+
+### Deploying
+We can deploy either by using Heroku's Docker plugin or by the Git plugin.
+
+- Deploy a new release using Heroku's Docker plugin -- `heroku docker:release --app {APP_NAME}`
+- Deploy using Heroku's Git plugin -- `git push {HEROKU_GIT_REMOTE_NAME} master`

--- a/app.json
+++ b/app.json
@@ -1,0 +1,11 @@
+{
+  "name": "Screens",
+  "description": "A way to distribute websites to multiple displays.",
+  "website": "http://ftlabs-screens.herokuapp.com/",
+  "repository": "https://github.com/ftlabs/screens",
+  "success_url": "/admin",
+  "image": "jakechampion/heroku-nodejs",
+  "addons": [
+    "redistogo"
+  ]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 web:
   build: .
-  command: 'bash -c ''npm start'''
+  command: 'npm start'
   working_dir: /app/user
   environment:
     PORT: 8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+web:
+  build: .
+  command: 'bash -c ''npm start'''
+  working_dir: /app/user
+  environment:
+    PORT: 8080
+  ports:
+    - '8080:8080'
+  volumes:
+    - '.:/app/user'
+  links:
+    - redis
+redis:
+  image: redis
+  volumes:
+    - .:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,4 +13,4 @@ web:
 redis:
   image: redis
   volumes:
-    - .:/data
+    - ./redis/data:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ web:
   ports:
     - '8080:8080'
   volumes:
-    - '.:/app/user'
+    - '.:/app/user' # This overwrites the /app/user directory in the container with the files/folders in this projects directory
   links:
     - redis
 redis:

--- a/server/log.js
+++ b/server/log.js
@@ -57,8 +57,8 @@ module.exports = {
 	renderView // Function
 };
 
-if (process.env.REDISTOGO_URL) {
-	const rtg   = require("url").parse(process.env.REDISTOGO_URL);
+if (process.env.REDISTOGO_URL || process.env.REDIS_PORT) {
+	const rtg = require('url').parse(process.env.REDISTOGO_URL || process.env.REDIS_PORT);
 	redis = Redis.createClient(rtg.port, rtg.hostname);
 	if (rtg.auth) redis.auth(rtg.auth.split(":")[1]);
 } else {


### PR DESCRIPTION
This PR adds the ability to use Docker for development and Heroku's Docker plugin for deployment. We can still deploy the application via `git`, the changes in this PR should be backwards compatible with current development and deployment strategies.

Fixes https://github.com/ftlabs/screens/issues/39
