### PR TITLE
MODIFIED: unreverse order of logs displayed

### DIFF
--- a/server/log.js
+++ b/server/log.js
@@ -152,7 +152,7 @@ function renderView(req, res) {
 			log.eventDesc = getTypeDescription(log);
 		});
 
-		logs.reverse();
+		// logs.reverse();
 
 		res.render('logs', {
 			logs,

--- a/server/log.js
+++ b/server/log.js
@@ -152,8 +152,6 @@ function renderView(req, res) {
 			log.eventDesc = getTypeDescription(log);
 		});
 
-		// logs.reverse();
-
 		res.render('logs', {
 			logs,
 			app: 'logs'


### PR DESCRIPTION
#89 minor tweak to remove reverse of logs
#85 issue re logs displaying 1month+ data. Fixes the previous fix.

One minor tweak (the fix) is to use LRANGE from the 0 end of the list, 
plus a bunch of refactoring.
