### PR TITLE
Fix the CSS in the image viewer

### DIFF
--- a/views/generators-image-viewer.handlebars
+++ b/views/generators-image-viewer.handlebars
@@ -1,5 +1,4 @@
-<!-- <link rel="stylesheet" href="https://origami-build.ft.com/v2/bundles/css?modules=o-fonts@^1.6.7,o-ft-icons@^2.4.1,o-header@^3,o-grid@^3,o-forms@^1,o-colors@^3,o-buttons@^3" /> -->
-<link rel="stylesheet" href="https://origami-build.ft.com/v2/bundles/css?modules=o-fonts%401.8.4%2Co-ft-icons%402.4.1%2Co-header%403.0.6%2Co-grid%403.2.6%2Co-forms%401.0.3%2Co-colors%403.3.2%2Co-buttons%403.1.3%2Co-autoinit%401.2.0&shrinkwrap=ftdomdelegate%402.0.3%2Clodash%403.10.1-npm%2Co-assets%402.0.0%2Co-dom%401.0.0%2Co-hierarchical-nav%402.1.4%2Co-hoverable%401.2.0%2Co-layers%401.1.2%2Co-squishy-list%401.2.0%2Co-viewport%401.5.0%2Csass-mq%403.2.9" />
+<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-fonts%401.8.4%2Co-autoinit%401.2.1&shrinkwrap=" />
 <style>
 
 	body, html, .holder{


### PR DESCRIPTION
The bundle requested included a lot of modules that were never used in
the page, and these were causing compilation errors.

We're now only requesting the modules that the page actually needs which
should prevent this from happening again.