### PR TITLE
Fix Build Service URLs across the app

### DIFF
--- a/public/index_old.html
+++ b/public/index_old.html
@@ -102,7 +102,7 @@
 		Load the Origami stylesheet, including fonts and icons by default.
 		Replace a,b,c with the names of the additional modules you want to load.
 	-->
-	<link rel="stylesheet" href="https://origami-build.ft.com/bundles/css?modules=o-fonts@^1.8.2,o-colors@^3.0.0,o-ft-icons@^2.3.7,o-overlay@^1.5.0" />
+	<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/bundles/css?modules=o-fonts@^1.8.2,o-colors@^3.0.0,o-ft-icons@^2.3.7,o-overlay@^1.5.0" />
 
 	<!--
 		Unconditionally load the polyfill service to provide the best support
@@ -127,7 +127,7 @@
 				var s = document.getElementsByTagName('script')[0];
 				s.parentNode.insertBefore(o, s);
 			}
-		}('https://origami-build.ft.com/bundles/js?modules=o-fonts@^1.8.2,o-colors@^3.0.0,o-ft-icons@^2.3.7,o-overlay@^1.5.0'));
+		}('https://www.ft.com/__origami/service/build/bundles/js?modules=o-fonts@^1.8.2,o-colors@^3.0.0,o-ft-icons@^2.3.7,o-overlay@^1.5.0'));
 	</script>
 </head>
 <body>

--- a/views/generators-image-viewer.handlebars
+++ b/views/generators-image-viewer.handlebars
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-fonts%401.8.4%2Co-autoinit%401.2.1&shrinkwrap=" />
+<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-fonts%401.8.4%2Co-autoinit%401.2.1" />
 <style>
 
 	body, html, .holder{
@@ -78,4 +78,3 @@
 
 
 </script>
-

--- a/views/generators-layout-admin.handlebars
+++ b/views/generators-layout-admin.handlebars
@@ -1,5 +1,4 @@
-<!-- <link rel="stylesheet" href="https://origami-build.ft.com/v2/bundles/css?modules=o-fonts@^1.6.7,o-ft-icons@^2.4.1,o-header@^3,o-grid@^3,o-forms@^1,o-colors@^3,o-buttons@^3" /> -->
-<link rel="stylesheet" href="https://origami-build.ft.com/v2/bundles/css?modules=o-fonts%401.8.4%2Co-ft-icons%402.4.1%2Co-header%403.0.6%2Co-grid%403.2.6%2Co-forms%401.0.3%2Co-colors%403.3.2%2Co-buttons%403.1.3%2Co-autoinit%401.2.0&shrinkwrap=ftdomdelegate%402.0.3%2Clodash%403.10.1-npm%2Co-assets%402.0.0%2Co-dom%401.0.0%2Co-hierarchical-nav%402.1.4%2Co-hoverable%401.2.0%2Co-layers%401.1.2%2Co-squishy-list%401.2.0%2Co-viewport%401.5.0%2Csass-mq%403.2.9" />
+<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-fonts@^1.6.7,o-ft-icons@^2.4.1,o-header@^3,o-grid@^3,o-forms@^1,o-colors@^3,o-buttons@^3" />
 <style>
 	html {
 			/* Set a font family on the whole document */

--- a/views/generators-markdown-admin.handlebars
+++ b/views/generators-markdown-admin.handlebars
@@ -1,5 +1,4 @@
-<!-- <link rel="stylesheet" href="https://origami-build.ft.com/v2/bundles/css?modules=o-fonts@^1.6.7,o-ft-icons@^2.4.1,o-header@^3,o-grid@^3,o-forms@^1,o-colors@^3,o-buttons@^3" /> -->
-<link rel="stylesheet" href="https://origami-build.ft.com/v2/bundles/css?modules=o-fonts%401.8.4%2Co-ft-icons%402.4.1%2Co-header%403.0.6%2Co-grid%403.2.6%2Co-forms%401.0.3%2Co-colors%403.3.2%2Co-buttons%403.1.3%2Co-autoinit%401.2.0&shrinkwrap=ftdomdelegate%402.0.3%2Clodash%403.10.1-npm%2Co-assets%402.0.0%2Co-dom%401.0.0%2Co-hierarchical-nav%402.1.4%2Co-hoverable%401.2.0%2Co-layers%401.1.2%2Co-squishy-list%401.2.0%2Co-viewport%401.5.0%2Csass-mq%403.2.9" />
+<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-fonts@^1.6.7,o-ft-icons@^2.4.1,o-header@^3,o-grid@^3,o-forms@^1,o-colors@^3,o-buttons@^3" />
 <style>
 
 	html, body{
@@ -219,4 +218,3 @@
 
 
 </script>
-

--- a/views/generators-markdown-view.handlebars
+++ b/views/generators-markdown-view.handlebars
@@ -1,5 +1,4 @@
-<!-- <link rel="stylesheet" href="https://origami-build.ft.com/v2/bundles/css?modules=o-fonts@^1.6.7,o-ft-icons@^2.4.1,o-header@^3,o-grid@^3,o-forms@^1,o-colors@^3,o-buttons@^3" /> -->
-<link rel="stylesheet" href="https://origami-build.ft.com/v2/bundles/css?modules=o-fonts%401.8.4%2Co-ft-icons%402.4.1%2Co-header%403.0.6%2Co-grid%403.2.6%2Co-forms%401.0.3%2Co-colors%403.3.2%2Co-buttons%403.1.3%2Co-autoinit%401.2.0&shrinkwrap=ftdomdelegate%402.0.3%2Clodash%403.10.1-npm%2Co-assets%402.0.0%2Co-dom%401.0.0%2Co-hierarchical-nav%402.1.4%2Co-hoverable%401.2.0%2Co-layers%401.1.2%2Co-squishy-list%401.2.0%2Co-viewport%401.5.0%2Csass-mq%403.2.9" />
+<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-fonts@^1.6.7,o-ft-icons@^2.4.1,o-header@^3,o-grid@^3,o-forms@^1,o-colors@^3,o-buttons@^3" />
 <style>
 
 	html, body{

--- a/views/generators-ticker-viewer.handlebars
+++ b/views/generators-ticker-viewer.handlebars
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="https://origami-build.ft.com/bundles/css?modules=o-fonts@^1.6.7,o-ft-icons@^2.3.6" />
+<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/bundles/css?modules=o-fonts@^1.6.7,o-ft-icons@^2.3.6" />
 <style>
 
 	body, html {

--- a/views/generators-youtube-player.handlebars
+++ b/views/generators-youtube-player.handlebars
@@ -1,5 +1,5 @@
 <link href='/build/generator-youtube-player/bundle.css' rel='stylesheet' type='text/css'>
-<link rel="stylesheet" href="https://build.origami.ft.com/v2/bundles/css?modules=o-fonts@^1.8.4,o-ft-icons@^2.4.0,o-header@^4.0.0,o-grid@^4.0.0,o-forms@^2.0.0,o-colors@^3.3.0,o-buttons@^3.0.3,o-autoinit@^1.2.0&shrinkwrap=ftdomdelegate@^2.0.3,o-assets@^2.0.0,o-dom@^2.0.0,o-hierarchical-nav@^3.0.1,o-hoverable@^3.0.0,o-layers@^2.0.1,o-squishy-list@^2.0.0,o-viewport@^2.0.0" />
+<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-fonts@^1.8.4,o-ft-icons@^2.4.0,o-header@^4.0.0,o-grid@^4.0.0,o-forms@^2.0.0,o-colors@^3.3.0,o-buttons@^3.0.3,o-autoinit@^1.2.0" />
 
 
 <div class="logo"></div>
@@ -11,4 +11,3 @@
 </div>
 <script src="/build/generator-youtube-player/bundle.js"></script>
 <script src="https://www.youtube.com/iframe_api"></script>
-


### PR DESCRIPTION
This updates the Build Service hostname and removes shrinkwrapping,
which was causing builds to fail.